### PR TITLE
[SASS-AddFeatureSwitchLibrary] Add Feature Switch Library for dynamic…

### DIFF
--- a/app/actions/AuthorisedAction.scala
+++ b/app/actions/AuthorisedAction.scala
@@ -19,6 +19,7 @@ package actions
 import common.{DelegatedAuthRules, EnrolmentIdentifiers, EnrolmentKeys, SessionValues}
 import config.AppConfig
 import controllers.errors.routes.{AgentAuthErrorController, IndividualAuthErrorController, UnauthorisedUserErrorController}
+import featureswitch.core.config.EmaSupportingAgent
 import models.{AuthorisationRequest, User}
 import play.api.Logger
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -127,7 +128,7 @@ class AuthorisedAction @Inject()(appConfig: AppConfig)
     case _: NoActiveSession =>
       logger.info(s"$agentAuthLogString - No active session. Redirecting to ${appConfig.signInUrl}")
       signInRedirectFutureResult
-    case _: AuthorisationException if appConfig.emaSupportingAgentsEnabled =>
+    case _: AuthorisationException if appConfig.isEnabled(EmaSupportingAgent) =>
       authService.authorised(secondaryAgentPredicate(mtdItId))
         .retrieve(allEnrolments)(
           enrolments => handleForValidAgent(block, mtdItId, nino, enrolments, isSupportingAgent = true)

--- a/app/actions/TailoringEnabledFilterAction.scala
+++ b/app/actions/TailoringEnabledFilterAction.scala
@@ -17,6 +17,7 @@
 package actions
 
 import config.AppConfig
+import featureswitch.core.config.Tailoring
 import models.AuthorisationRequest
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionFilter, Result}
@@ -30,7 +31,7 @@ case class TailoringEnabledFilterAction(taxYear: Int,
   override protected[actions] def executionContext: ExecutionContext = ec
 
   override protected[actions] def filter[A](request: AuthorisationRequest[A]): Future[Option[Result]] = Future.successful {
-    if (appConfig.tailoringEnabled) {
+    if (appConfig.isEnabled(Tailoring)) {
       None
     } else {
       Some(Redirect(appConfig.incomeTaxSubmissionOverviewUrl(taxYear)))

--- a/app/actions/TaxYearAction.scala
+++ b/app/actions/TaxYearAction.scala
@@ -18,6 +18,7 @@ package actions
 
 import common.SessionValues._
 import config.AppConfig
+import featureswitch.core.config.TaxYearError
 import models.AuthorisationRequest
 import play.api.Logger
 import play.api.mvc.Results.Redirect
@@ -40,7 +41,7 @@ class TaxYearAction @Inject()(taxYear: Int,
     implicit val implicitUser: AuthorisationRequest[A] = request
 
     def taxYearListCheck(validTaxYears: Seq[Int]): Either[Result, AuthorisationRequest[A]] = {
-      if (!appConfig.taxYearErrorFeature || validTaxYears.contains(taxYear)) {
+      if (!appConfig.isEnabled(TaxYearError) || validTaxYears.contains(taxYear)) {
         val sameTaxYear = request.session.get(TAX_YEAR).exists(_.toInt == taxYear)
         if (sameTaxYear) {
           Right(request)

--- a/app/controllers/ContractorCYAController.scala
+++ b/app/controllers/ContractorCYAController.scala
@@ -20,6 +20,7 @@ import actions.ActionsProvider
 import common.SessionValues
 import config.{AppConfig, ErrorHandler}
 import controllers.routes._
+import featureswitch.core.config.SectionCompletedQuestion
 import models.pages.ContractorCYAPage._
 import models.{HttpParserError, InvalidOrUnfinishedSubmission, UserSessionDataRequest}
 import play.api.i18n.I18nSupport
@@ -47,7 +48,7 @@ class ContractorCYAController @Inject()(actionsProvider: ActionsProvider,
     if (inYearUtil.inYear(taxYear)) inYear(taxYear, month, contractor) else endOfYear(taxYear, month, contractor)
 
   private def redirectTo(taxYear: Int, contractor: String)(implicit request: UserSessionDataRequest[_]): Result =
-    if (appConfig.sectionCompletedQuestionEnabled){
+    if (appConfig.isEnabled(SectionCompletedQuestion)){
       Redirect(SectionCompletedController.show(taxYear, "cis"))
     } else {
       Redirect(ContractorSummaryController.show(taxYear, contractor))

--- a/app/controllers/DeductionsSummaryController.scala
+++ b/app/controllers/DeductionsSummaryController.scala
@@ -18,6 +18,7 @@ package controllers
 
 import actions.ActionsProvider
 import config.{AppConfig, ErrorHandler}
+import featureswitch.core.config.Tailoring
 import models.pages.DeductionsSummaryPage
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -38,7 +39,7 @@ class DeductionsSummaryController @Inject()(actionsProvider: ActionsProvider,
   extends FrontendController(cc) with I18nSupport with SessionHelper {
 
   def show(taxYear: Int): Action[AnyContent] = actionsProvider.priorCisDeductionsData(taxYear).async { implicit request =>
-    if (appConfig.tailoringEnabled){
+    if (appConfig.isEnabled(Tailoring)){
       tailoringService.getExcludedJourneys(taxYear = taxYear, request.user.nino, request.user.mtditid).map {
         case Left(_) => errorHandler.internalServerError()
         case Right(result) =>

--- a/app/featureswitch/api/controllers/FeatureSwitchApiController.scala
+++ b/app/featureswitch/api/controllers/FeatureSwitchApiController.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.api.controllers
+
+import featureswitch.api.services.FeatureSwitchService
+import featureswitch.core.models.FeatureSwitchSetting
+import featureswitch.core.models.FeatureSwitchSetting._
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, InjectedController}
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class FeatureSwitchApiController @Inject()(featureSwitchService: FeatureSwitchService) extends InjectedController {
+
+  def getFeatureSwitches: Action[AnyContent] = Action {
+    Ok(Json.toJson(featureSwitchService.getFeatureSwitches()))
+  }
+
+  def updateFeatureSwitches(): Action[Seq[FeatureSwitchSetting]] = Action(parse.json[Seq[FeatureSwitchSetting]]) {
+    req =>
+      val updatedFeatureSwitches = featureSwitchService.updateFeatureSwitches(req.body)
+      Ok(Json.toJson(updatedFeatureSwitches))
+  }
+
+}

--- a/app/featureswitch/api/services/FeatureSwitchService.scala
+++ b/app/featureswitch/api/services/FeatureSwitchService.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.api.services
+
+import config.AppConfig
+import featureswitch.core.config.FeatureSwitchRegistry
+import featureswitch.core.models.FeatureSwitchSetting
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class FeatureSwitchService @Inject()(featureSwitchRegistry: FeatureSwitchRegistry,
+                                     val config: AppConfig) {
+
+  def getFeatureSwitches(): Seq[FeatureSwitchSetting] =
+    featureSwitchRegistry.switches.map(
+      switch =>
+        FeatureSwitchSetting(
+          switch.configName,
+          switch.displayName,
+          config.isEnabled(switch)
+        )
+    )
+
+  def updateFeatureSwitches(updatedFeatureSwitches: Seq[FeatureSwitchSetting]): Seq[FeatureSwitchSetting] = {
+    updatedFeatureSwitches.foreach(
+      featureSwitchSetting =>
+        featureSwitchRegistry.get(featureSwitchSetting.configName).foreach {
+          featureSwitch =>
+            if (featureSwitchSetting.isEnabled) config.enable(featureSwitch) else config.disable(featureSwitch)
+        }
+    )
+
+    getFeatureSwitches()
+  }
+}

--- a/app/featureswitch/core/config/FeatureSwitchRegistry.scala
+++ b/app/featureswitch/core/config/FeatureSwitchRegistry.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.config
+
+import featureswitch.core.models.FeatureSwitch
+
+trait FeatureSwitchRegistry {
+
+  def switches: Seq[FeatureSwitch]
+
+  def apply(name: String): FeatureSwitch =
+    get(name) match {
+      case Some(switch) => switch
+      case None => throw new IllegalArgumentException("Invalid feature switch: " + name)
+    }
+
+  def get(name: String): Option[FeatureSwitch] = switches find (_.configName == name)
+
+}

--- a/app/featureswitch/core/config/FeatureSwitching.scala
+++ b/app/featureswitch/core/config/FeatureSwitching.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.config
+
+import config.AppConfig
+import featureswitch.core.models.FeatureSwitch
+import play.api.Logging
+
+trait FeatureSwitching extends Logging { config: AppConfig =>
+
+  def isEnabled(featureSwitch: FeatureSwitch): Boolean =
+    sys.props get featureSwitch.configName match {
+      case Some(value) => value.toBoolean
+      case None => config.getFeatureSwitchValue(featureSwitch.configName)
+    }
+
+  def enable(featureSwitch: FeatureSwitch): Unit = {
+    logger.warn(s"[enable] $featureSwitch")
+    sys.props += featureSwitch.configName -> true.toString
+  }
+
+  def disable(featureSwitch: FeatureSwitch): Unit = {
+    logger.warn(s"[disable] $featureSwitch")
+    sys.props += featureSwitch.configName -> false.toString
+  }
+}

--- a/app/featureswitch/core/config/FeatureSwitchingModule.scala
+++ b/app/featureswitch/core/config/FeatureSwitchingModule.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.config
+
+import featureswitch.core.models.FeatureSwitch
+import play.api.inject.{Binding, Module}
+import play.api.{Configuration, Environment}
+
+import javax.inject.Singleton
+
+@Singleton
+class FeatureSwitchingModule extends Module with FeatureSwitchRegistry {
+
+  val switches: Seq[FeatureSwitch] = Seq(
+    AlwaysEOY,
+    TaxYearError,
+    WelshToggle,
+    Tailoring,
+    SectionCompletedQuestion,
+    UseEncryption,
+    EmaSupportingAgent
+  )
+
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+    Seq(
+      bind[FeatureSwitchRegistry].to(this).eagerly()
+    )
+  }
+}
+
+case object AlwaysEOY extends FeatureSwitch {
+  override val configName: String = prefix + "alwaysEOY"
+  override val displayName: String = "Always EOY enabled"
+}
+
+case object TaxYearError extends FeatureSwitch {
+  override val configName: String = prefix + "taxYearErrorFeatureSwitch"
+  override val displayName: String = "Tax Tear Error enabled"
+}
+
+case object WelshToggle extends FeatureSwitch {
+  override val configName: String = prefix + "welshToggleEnabled"
+  override val displayName: String = "Welsh Translation enabled"
+}
+
+case object Tailoring extends FeatureSwitch {
+  override val configName: String = prefix + "tailoringEnabled"
+  override val displayName: String = "Tailoring enabled"
+}
+
+case object SectionCompletedQuestion extends FeatureSwitch {
+  override val configName: String = prefix + "sectionCompletedQuestionEnabled"
+  override val displayName: String = "Section Completed Question enabled"
+}
+
+case object UseEncryption extends FeatureSwitch {
+  override val configName: String = prefix + "useEncryption"
+  override val displayName: String = "Use Encryption enabled"
+}
+
+case object EmaSupportingAgent extends FeatureSwitch {
+  override val configName: String = prefix + "ema-supporting-agents-enabled"
+  override val displayName: String = "EMA Support Agents enabled"
+}
+

--- a/app/featureswitch/core/models/FeatureSwitch.scala
+++ b/app/featureswitch/core/models/FeatureSwitch.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.models
+
+trait FeatureSwitch {
+  val prefix = "feature-switch."
+  val configName: String
+  val displayName: String
+}

--- a/app/featureswitch/core/models/FeatureSwitchSetting.scala
+++ b/app/featureswitch/core/models/FeatureSwitchSetting.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.core.models
+
+import play.api.libs.json.{Json, OFormat}
+
+
+case class FeatureSwitchSetting(configName: String,
+                                displayName: String,
+                                isEnabled: Boolean)
+
+object FeatureSwitchSetting {
+
+  implicit val format: OFormat[FeatureSwitchSetting] = Json.format[FeatureSwitchSetting]
+
+}

--- a/app/featureswitch/frontend/config/FeatureSwitchProviderConfig.scala
+++ b/app/featureswitch/frontend/config/FeatureSwitchProviderConfig.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.frontend.config
+
+import config.AppConfig
+import featureswitch.frontend.models.FeatureSwitchProvider
+import play.api.Configuration
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class FeatureSwitchProviderConfig @Inject()(configuration: Configuration, appConfig: AppConfig) {
+
+  val servicesConfig = new ServicesConfig(configuration)
+
+  lazy val selfFeatureSwitchProvider: FeatureSwitchProvider = FeatureSwitchProvider(
+    id = "income-tax-cis-frontend",
+    appName = "Income Tax CIS Frontend",
+    url = appConfig.selfUrl + featureswitch.api.controllers.routes.FeatureSwitchApiController.getFeatureSwitches()
+  )
+
+  lazy val cisBackendProvider: FeatureSwitchProvider = FeatureSwitchProvider(
+    id = "income-tax-cis",
+    appName = "Income Tax CIS Backend",
+    url = appConfig.incomeTaxCISBEUrl + "/test-only/api/feature-switches"
+  )
+
+  lazy val featureSwitchProviders: Seq[FeatureSwitchProvider] =
+    Seq(selfFeatureSwitchProvider, cisBackendProvider)
+
+}

--- a/app/featureswitch/frontend/connectors/FeatureSwitchApiConnector.scala
+++ b/app/featureswitch/frontend/connectors/FeatureSwitchApiConnector.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.frontend.connectors
+
+import featureswitch.core.models.FeatureSwitchSetting
+import play.api.http.Status._
+import play.api.libs.json.{JsError, JsSuccess, Reads}
+import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class FeatureSwitchApiConnector @Inject()(httpClient: HttpClient)(implicit ec: ExecutionContext) {
+
+  def retrieveFeatureSwitches(featureSwitchProviderUrl: String
+                             )(implicit reads: Reads[Seq[FeatureSwitchSetting]],
+                               hc: HeaderCarrier): Future[Seq[FeatureSwitchSetting]] = {
+    httpClient.GET(featureSwitchProviderUrl).map(
+      response =>
+        response.status match {
+          case OK =>
+            response.json.validate[Seq[FeatureSwitchSetting]] match {
+              case JsSuccess(settings, _) => settings
+              case JsError(errors) => throw new Exception(errors.head.toString)
+            }
+          case _ => throw new Exception(s"Could not retrieve feature switches from $featureSwitchProviderUrl")
+        }
+    )
+  }
+
+  def updateFeatureSwitches(featureSwitchProviderUrl: String,
+                            featureSwitchSettings: Seq[FeatureSwitchSetting]
+                           )(implicit hc: HeaderCarrier): Future[Seq[FeatureSwitchSetting]] = {
+    httpClient.POST(featureSwitchProviderUrl, featureSwitchSettings).map {
+      response =>
+        response.status match {
+          case OK =>
+            response.json.validate[Seq[FeatureSwitchSetting]] match {
+              case JsSuccess(settings, _) => settings
+              case JsError(errors) => throw new Exception(errors.head.toString)
+            }
+          case _ => throw new Exception(s"Could not retrieve feature switches from $featureSwitchProviderUrl")
+        }
+    }
+  }
+
+}

--- a/app/featureswitch/frontend/controllers/FeatureSwitchFrontendController.scala
+++ b/app/featureswitch/frontend/controllers/FeatureSwitchFrontendController.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.frontend.controllers
+
+import config.AppConfig
+import featureswitch.frontend.services.FeatureSwitchRetrievalService
+import featureswitch.frontend.views.html.feature_switch
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class FeatureSwitchFrontendController @Inject()(featureSwitchService: FeatureSwitchRetrievalService,
+                                                featureSwitchView: feature_switch,
+                                                mcc: MessagesControllerComponents
+                                               )(implicit ec: ExecutionContext, val config: AppConfig) extends FrontendController(mcc) with I18nSupport {
+
+
+  def show(): Action[AnyContent] = Action.async {
+    implicit req =>
+      featureSwitchService.retrieveFeatureSwitches().map {
+        featureSwitches =>
+          Ok(featureSwitchView(featureSwitches, routes.FeatureSwitchFrontendController.submit()))
+      }
+  }
+
+  def submit(): Action[Map[String, Seq[String]]] = Action.async(parse.formUrlEncoded) {
+    implicit req =>
+      featureSwitchService.updateFeatureSwitches(req.body.keys).map {
+        featureSwitches =>
+          Ok(featureSwitchView(featureSwitches, routes.FeatureSwitchFrontendController.submit()))
+      }
+  }
+}

--- a/app/featureswitch/frontend/models/FeatureSwitchProvider.scala
+++ b/app/featureswitch/frontend/models/FeatureSwitchProvider.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.frontend.models
+
+case class FeatureSwitchProvider(id: String,
+                                 appName: String,
+                                 url: String)

--- a/app/featureswitch/frontend/services/FeatureSwitchRetrievalService.scala
+++ b/app/featureswitch/frontend/services/FeatureSwitchRetrievalService.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package featureswitch.frontend.services
+
+import featureswitch.core.models.FeatureSwitchSetting
+import featureswitch.frontend.config.FeatureSwitchProviderConfig
+import featureswitch.frontend.connectors.FeatureSwitchApiConnector
+import featureswitch.frontend.models.FeatureSwitchProvider
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.matching.Regex
+
+class FeatureSwitchRetrievalService @Inject()(featureSwitchConfig: FeatureSwitchProviderConfig,
+                                              featureSwitchApiConnector: FeatureSwitchApiConnector)
+                                             (implicit ec: ExecutionContext) {
+
+  def retrieveFeatureSwitches()(implicit hc: HeaderCarrier): Future[Seq[(FeatureSwitchProvider, Seq[FeatureSwitchSetting])]] = {
+
+    val featureSwitchSeq: Seq[(FeatureSwitchProvider, Future[Seq[FeatureSwitchSetting]])] =
+      featureSwitchConfig.featureSwitchProviders.map {
+        featureSwitchProvider =>
+          featureSwitchProvider -> featureSwitchApiConnector.retrieveFeatureSwitches(featureSwitchProvider.url)
+      }
+
+    Future.traverse(featureSwitchSeq) {
+      case (featureSwitchProvider, futureSeqFeatureSwitchSetting) =>
+        futureSeqFeatureSwitchSetting.map {
+          featureSwitchSettingSeq => featureSwitchProvider -> featureSwitchSettingSeq
+        }
+    }
+  }
+
+  val featureSwitchKeyRegex: Regex = "(.+?)\\.(.+)".r
+
+  def updateFeatureSwitches(updatedFeatureSwitchKeys: Iterable[String]
+                           )(implicit hc: HeaderCarrier): Future[Seq[(FeatureSwitchProvider, Seq[FeatureSwitchSetting])]] = {
+    val updatedFeatureSwitches: Future[Seq[(FeatureSwitchProvider, Seq[FeatureSwitchSetting])]] =
+      retrieveFeatureSwitches().map {
+        currentFeatureSwitches =>
+          currentFeatureSwitches.map {
+            case (featureSwitchProvider, providerFeatureSwitches) =>
+              featureSwitchProvider -> providerFeatureSwitches.map {
+                currentFeatureSwitch =>
+                  val isEnabled = updatedFeatureSwitchKeys.exists {
+                    case featureSwitchKeyRegex(microserviceKey, featureSwitchKey) =>
+                      microserviceKey == featureSwitchProvider.id && featureSwitchKey == currentFeatureSwitch.configName
+                    case _ =>
+                      false
+                  }
+                  currentFeatureSwitch.copy(isEnabled = isEnabled)
+              }
+          }
+      }
+
+    updatedFeatureSwitches.flatMap {
+      Future.traverse(_) {
+        case (featureSwitchProvider, featureSwitchSettings) =>
+          featureSwitchApiConnector.updateFeatureSwitches(featureSwitchProvider.url, featureSwitchSettings).map {
+            updatedFeatureSwitches => featureSwitchProvider -> updatedFeatureSwitches
+          }
+      }
+    }
+  }
+
+}

--- a/app/featureswitch/frontend/views/feature_switch.scala.html
+++ b/app/featureswitch/frontend/views/feature_switch.scala.html
@@ -1,0 +1,64 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import featureswitch.core.models.FeatureSwitchSetting
+@import featureswitch.frontend.models.FeatureSwitchProvider
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.templates.Layout
+
+
+@this(layout: Layout,
+        govukCheckboxes: GovukCheckboxes,
+        govukButton: GovukButton,
+        formWithCSRF: FormWithCSRF
+)
+
+@(featureSwitchList: Seq[(FeatureSwitchProvider, Seq[FeatureSwitchSetting])], formAction: Call)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@layout("Choose which features to enable.") {
+    <h1 class="govuk-heading-l" >Choose which features to enable.</h1>
+
+    @formWithCSRF(action = formAction) {
+        @for(featureSwitches <- featureSwitchList) {
+            @govukCheckboxes(Checkboxes(
+                fieldset = Some(Fieldset(
+                    legend = Some(Legend(
+                        content = Text(featureSwitches._1.appName),
+                        classes = "govuk-fieldset__legend--m",
+                        isPageHeading = false
+                    ))
+                )),
+                idPrefix = Some(featureSwitches._1.id),
+                name = "feature-switch",
+                items = featureSwitches._2.map {
+                    featureSwitchSettings =>
+                        CheckboxItem(
+                            id = Some(featureSwitchSettings.configName),
+                            name = Some(s"${featureSwitches._1.id}.${featureSwitchSettings.configName}"),
+                            content = Text(featureSwitchSettings.displayName),
+                            checked = featureSwitchSettings.isEnabled
+                        )
+                }
+            ))
+        }
+
+        @govukButton(Button(
+            classes = "govuk-!-margin-right-1",
+            content = Text("Submit")
+        ))
+    }
+}

--- a/app/utils/AesGcmAdCrypto.scala
+++ b/app/utils/AesGcmAdCrypto.scala
@@ -17,6 +17,7 @@
 package utils
 
 import config.AppConfig
+import featureswitch.core.config.UseEncryption
 import uk.gov.hmrc.crypto.EncryptedValue
 
 import javax.inject.{Inject, Singleton}
@@ -29,7 +30,7 @@ class AesGcmAdCrypto @Inject()(appConfig: AppConfig,
 
   def encrypt(valueToEncrypt: String)
              (implicit associatedText: String): EncryptedValue = {
-    if (appConfig.useEncryption) {
+    if (appConfig.isEnabled(UseEncryption)) {
       aesGcmAdCrypto.encrypt(valueToEncrypt, associatedText)
     } else {
       EncryptedValue(valueToEncrypt, s"$valueToEncrypt-Nonce")
@@ -38,7 +39,7 @@ class AesGcmAdCrypto @Inject()(appConfig: AppConfig,
 
   def decrypt(encryptedValue: EncryptedValue)
              (implicit associatedText: String): String = {
-    if (appConfig.useEncryption) {
+    if (appConfig.isEnabled(UseEncryption)) {
       aesGcmAdCrypto.decrypt(encryptedValue, associatedText)
     } else {
       encryptedValue.value

--- a/app/utils/InYearUtil.scala
+++ b/app/utils/InYearUtil.scala
@@ -17,6 +17,7 @@
 package utils
 
 import config.AppConfig
+import featureswitch.core.config.AlwaysEOY
 import play.api.Logger
 
 import java.time.{LocalDateTime, ZoneId}
@@ -44,7 +45,7 @@ class InYearUtil @Inject()(implicit appConfig: AppConfig) {
       logger.info(s"[InYearAction][inYear] CIS pages for this request will not be in year.")
     }
 
-    if (appConfig.alwaysEOY) {
+    if (appConfig.isEnabled(AlwaysEOY)) {
       false
     } else {
       isNowBefore

--- a/app/views/DeductionsSummaryView.scala.html
+++ b/app/views/DeductionsSummaryView.scala.html
@@ -23,6 +23,7 @@
 @import controllers.routes.ContractorSummaryController
 @import controllers.routes.DeductionsFromPaymentsController
 @import utils.ViewUtils.summaryListRow
+@import featureswitch.core.config.Tailoring
 
 @this(
     layout: Layout,
@@ -42,7 +43,7 @@
 
 @heading(title, Some(messages("cis.caption", (pageModel.taxYear - 1).toString, pageModel.taxYear.toString)), "govuk-!-margin-bottom-2")
 
-@if(appConfig.tailoringEnabled && !pageModel.isInYear) {
+@if(appConfig.isEnabled(Tailoring) && !pageModel.isInYear) {
 @govukSummaryList(SummaryList(Seq(summaryListRow(
 HtmlContent(messages("deductionsSummary.title")),
 HtmlContent( if(pageModel.gateway) messages("common.yes") else messages("common.no")),

--- a/app/views/templates/BeforeBodyContent.scala.html
+++ b/app/views/templates/BeforeBodyContent.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import views.html.templates.helpers.BetaBar
+@import featureswitch.core.config.WelshToggle
 
 @this(betaBar: BetaBar,hmrcLanguageSelect : HmrcLanguageSelect,govukBackLink: GovukBackLink)
 
@@ -22,7 +23,7 @@
 
 @betaBar(isAgent)
 
-@if(appConfig.welshToggleEnabled) {
+@if(appConfig.isEnabled(WelshToggle)) {
  @hmrcLanguageSelect(LanguageSelect(
    language = utils.LanguageUtil.checkLanguage,
      En -> appConfig.routeToSwitchLanguage("english").toString,

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ lazy val coverageSettings: Seq[Setting[?]] = {
     "testOnly.*",
     "testOnlyDoNotUseInAppConf.*",
     ".*feedback*.*",
+    ".*featureswitch.*",
     "partials.*",
     "controllers.testOnly.*",
     "forms.validation.mappings",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,6 +54,7 @@ play.http.errorHandler = "config.ErrorHandler"
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 play.modules.enabled += "config.Modules"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
+play.modules.enabled += "featureswitch.core.config.FeatureSwitchingModule"
 
 microservice {
 
@@ -64,6 +65,12 @@ microservice {
     auth {
       host = localhost
       port = 8500
+    }
+
+    income-tax-cis-frontend {
+      protocol = http
+      host = localhost
+      port = 9338
     }
 
     contact-frontend {
@@ -131,21 +138,21 @@ mongodb {
 accessibility-statement.service-path = "/income-tax-submission"
 
 defaultTaxYear = 2023
-alwaysEOY = false
 
 timeoutDialogTimeout = 900
 timeoutDialogCountdown = 120
 
-taxYearErrorFeatureSwitch = false
 
 feature-switch {
+  alwaysEOY = false
+  taxYearErrorFeatureSwitch = false
   welshToggleEnabled = true
   tailoringEnabled = true
   sectionCompletedQuestionEnabled = true
+  useEncryption = false
   ema-supporting-agents-enabled = true
 }
 
-useEncryption = false
 
 tracking-consent-frontend {
   gtm.container = "b"

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,4 +10,11 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
+
+GET        /update-and-submit-income-tax-return/construction-industry-scheme-deductions/test-only/feature-switches        featureswitch.frontend.controllers.FeatureSwitchFrontendController.show()
+POST       /update-and-submit-income-tax-return/construction-industry-scheme-deductions/test-only/feature-switches        featureswitch.frontend.controllers.FeatureSwitchFrontendController.submit()
+GET        /update-and-submit-income-tax-return/construction-industry-scheme-deductions/test-only/api/feature-switches    featureswitch.api.controllers.FeatureSwitchApiController.getFeatureSwitches()
++ nocsrf
+POST       /update-and-submit-income-tax-return/construction-industry-scheme-deductions/test-only/api/feature-switches    featureswitch.api.controllers.FeatureSwitchApiController.updateFeatureSwitches()
+
 ->         /                          prod.Routes

--- a/it/test/support/IntegrationTest.scala
+++ b/it/test/support/IntegrationTest.scala
@@ -69,8 +69,8 @@ trait IntegrationTest extends AnyWordSpec
     "microservice.services.income-tax-submission.url" -> s"http://$wiremockHost:$wiremockPort",
     "microservice.services.view-and-change.url" -> s"http://$wiremockHost:$wiremockPort",
     "microservice.services.sign-in.url" -> s"/auth-login-stub/gg-sign-in",
-    "taxYearErrorFeatureSwitch" -> "false",
-    "useEncryption" -> "true",
+    "feature-switch.taxYearErrorFeatureSwitch" -> "false",
+    "feature-switch.useEncryption" -> "true",
     "feature-switch.tailoringEnabled" -> "false"
   )
 

--- a/test/actions/AuthorisedActionSpec.scala
+++ b/test/actions/AuthorisedActionSpec.scala
@@ -19,8 +19,10 @@ package actions
 import common.SessionValues.{CLIENT_MTDITID, CLIENT_NINO}
 import common.{EnrolmentIdentifiers, EnrolmentKeys, SessionValues}
 import config.AppConfig
+import featureswitch.core.config.EmaSupportingAgent
+import featureswitch.core.models.FeatureSwitch
 import models.AuthorisationRequest
-import org.scalamock.handlers.{CallHandler0, CallHandler4}
+import org.scalamock.handlers.{CallHandler0, CallHandler1, CallHandler4}
 import org.scalamock.scalatest.MockFactory
 import play.api.Play.materializer
 import play.api.http.Status._
@@ -123,9 +125,9 @@ class AuthorisedActionSpec extends ControllerUnitTest
         .withIdentifier("MTDITID", mtdId)
         .withDelegatedAuthRule("mtd-it-auth-supp")
 
-    def mockMultipleAgentsSwitch(bool: Boolean): CallHandler0[Boolean] =
-      (mockAppConfig.emaSupportingAgentsEnabled _: () => Boolean)
-        .expects()
+    def mockMultipleAgentsSwitch(bool: Boolean): CallHandler1[FeatureSwitch, Boolean] =
+      (mockAppConfig.isEnabled(_: FeatureSwitch))
+        .expects(EmaSupportingAgent)
         .returning(bool)
         .anyNumberOfTimes()
 

--- a/test/actions/TaxYearActionSpec.scala
+++ b/test/actions/TaxYearActionSpec.scala
@@ -19,6 +19,8 @@ package actions
 import common.SessionValues.{TAX_YEAR, VALID_TAX_YEARS}
 import config.AppConfig
 import controllers.errors.routes.TaxYearErrorController
+import featureswitch.core.config.TaxYearError
+import featureswitch.core.models.FeatureSwitch
 import models.AuthorisationRequest
 import org.scalamock.scalatest.MockFactory
 import play.api.http.Status.SEE_OTHER
@@ -56,7 +58,7 @@ class TaxYearActionSpec extends UnitTest
       "the tax year is within the list of valid tax years, and the tax year is equal to the session value if the feature switch is on" in {
         lazy val userRequest = AuthorisationRequest(aUser, request)
         lazy val result = {
-          (() => mockedConfig.taxYearErrorFeature).expects() returning true
+          (mockedConfig.isEnabled(_: FeatureSwitch)).expects(TaxYearError) returning true
           await(taxYearAction(validTaxYear).refine(userRequest))
         }
 
@@ -67,7 +69,7 @@ class TaxYearActionSpec extends UnitTest
         lazy val userRequest = anAuthorisationRequest.copy(request = fakeAgentRequest.withSession(TAX_YEAR -> validTaxYear.toString, VALID_TAX_YEARS -> validTaxYears))
 
         lazy val result = {
-          (() => mockedConfig.taxYearErrorFeature).expects() returning false
+          (mockedConfig.isEnabled(_: FeatureSwitch)).expects(TaxYearError) returning false
           await(taxYearAction(validTaxYear).refine(userRequest))
         }
 
@@ -97,7 +99,7 @@ class TaxYearActionSpec extends UnitTest
       "the tax year is different from that in session and the feature switch is off" which {
         lazy val userRequest = anAuthorisationRequest.copy(request = request)
         lazy val result = {
-          (() => mockedConfig.taxYearErrorFeature).expects() returning false
+          (mockedConfig.isEnabled(_: FeatureSwitch)).expects(TaxYearError) returning false
           mockedConfig.incomeTaxSubmissionOverviewUrl _ expects taxYearNotInSession returning
             "controllers.routes.OverviewPageController.show(taxYearNotInSession).url"
 
@@ -120,7 +122,7 @@ class TaxYearActionSpec extends UnitTest
       "the tax year is outside list of valid tax years and the feature switch is on" which {
         lazy val userRequest = anAuthorisationRequest.copy(request = request)
         lazy val result = {
-          (() => mockedConfig.taxYearErrorFeature).expects() returning true
+          (mockedConfig.isEnabled(_: FeatureSwitch)).expects(TaxYearError) returning true
           taxYearAction(invalidTaxYear).refine(userRequest)
         }
 

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -16,6 +16,7 @@
 
 package config
 
+import featureswitch.core.config.WelshToggle
 import org.scalamock.scalatest.MockFactory
 import support.{FakeRequestHelper, UnitTest}
 import uk.gov.hmrc.play.bootstrap.binders.SafeRedirectUrl
@@ -83,6 +84,36 @@ class AppConfigSpec extends UnitTest
       underTest.feedbackSurveyUrl shouldBe expectedFeedbackSurveyUrl
       underTest.contactUrl shouldBe expectedContactUrl
       underTest.signOutUrl shouldBe expectedSignOutUrl
+    }
+
+    ".isEnabled(fs: FeatureSwitch)" when {
+      "value has not been saved to Sys.props" should {
+        "return the value from AppConfig" in {
+          (mockServicesConfig.getBoolean _).expects(WelshToggle.configName).returns(false).once()
+          sys.props.get(WelshToggle.configName) shouldBe None
+          underTest.isEnabled(WelshToggle) shouldBe false
+        }
+      }
+
+      "value has been saved to Sys.pros" should {
+        "return `false`" when {
+          "feature is disabled" in {
+            (mockServicesConfig.getBoolean _).expects(WelshToggle.configName).never()
+            underTest.disable(WelshToggle)
+            sys.props.get(WelshToggle.configName) shouldBe Some("false")
+            underTest.isEnabled(WelshToggle) shouldBe false
+          }
+        }
+
+        "return `true`" when {
+          "feature is enabled" in {
+            (mockServicesConfig.getBoolean _).expects(WelshToggle.configName).never()
+            underTest.enable(WelshToggle)
+            sys.props.get(WelshToggle.configName) shouldBe Some("true")
+            underTest.isEnabled(WelshToggle) shouldBe true
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Description
This change allows the Feature Switch settings to be stored as Sys.props within the µService instance. This allows us to change whether features are enabled or disabled dynamically at will both locally and within QA/Staging.

There is a testOnly web page that enables this, it also can send switch changes to the CIS backend too.

App-Config-PR(s)
- https://github.com/hmrc/app-config-base/pull/11405
- https://github.com/hmrc/app-config-qa/pull/24142
- https://github.com/hmrc/app-config-staging/pull/16466
- https://github.com/hmrc/app-config-production/pull/24127


### Checklist PR Reviewer
##### Before Reviewing
- [ ]  Have you pulled the branch down?
- [ ]  Have you assigned yourself to the PR?
- [ ]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [ ]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [ ]  Have you rebased against the current version of main?
- [ ]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
